### PR TITLE
update PER support

### DIFF
--- a/games/lunarlander.py
+++ b/games/lunarlander.py
@@ -73,6 +73,10 @@ class MuZeroConfig:
         self.weight_decay = 1e-4  # L2 weights regularization
         self.momentum = 0.9
 
+        # Prioritized Replay
+        self.PER = True
+        self.PER_alpha = 0.5
+
         # Exponential learning rate schedule
         self.lr_init = 0.005  # Initial learning rate
         self.lr_decay_rate = 1  # Set it to 1 to use a constant learning rate

--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -87,7 +87,9 @@ class ReplayBuffer:
 
             # update position priorities
             priority = priorities[i, :]
-            numpy.put(self.buffer[game_index].priorities, range(game_pos, game_pos + len(priority)), priority, 'wrap')
+            start_index = game_pos
+            end_index = min(game_pos + len(priority), len(self.buffer[game_index].priorities))
+            numpy.put(self.buffer[game_index].priorities, range(start_index, end_index), priority)
 
             # update game priorities
             self.game_priorities[game_index] = numpy.mean(self.buffer[game_index].priorities)


### PR DESCRIPTION
Hi,

Thanks for your information!

For the 'wrap' mode in `numpy.put()`, you are correct. I fixed this line in this commit.

For the [mean](https://github.com/werner-duvaud/muzero-general/blob/prioritized_replay/replay_buffer.py#L24), I don't have a reference. Since we are first sampling games, and then sampling transitions from games, we need two prioritized sampling process, which is different from Prioritized Experience Replay paper. An alternative to the mean could be max, since after averaging, the transitions with high priorities may be affected. I'm still testing these two schemes.

- I also added an option to choose whether or not to use the priority replay (`self.PER` in the config file). If set to False, the algorithm will never update the priorities, thus all transitions will always have equal priorities (currently 1.0), which is equivalent to uniform sampling.

- I made alpha in PER algorithm configurable by adding `self.PER_alpha` in the config file.

For the remaining items on the list, here are my thoughts:

- Add the loss scaling using the importance sampling ratio. (I'm having trouble figuring out how to do this without turning the buffer into a very long list with all the steps of each game)

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I think to calculate the IS weights for each sample, we need $N$ and $P(i)$ in this formula:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img width="179" alt="is" src="https://user-images.githubusercontent.com/29387830/77222150-b4849480-6b1e-11ea-8aa3-3a9e4dcef169.png">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;where $N$ is the total number of transitions in the buffer, and $P(i)$ is the probability of transition $i$ get sampled, which can be calculated from game priorities and transition priorities.

- Maybe assign an initial value of probabilities based on the loss of root.value and the predicted value in MCTS (or 1 as you did, could be a parameter).

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;As suggested by the Distributed Prioritized Experience Replay paper (Page 4, paragraph 2), the initial priority can be either set to the "maximum priority seen so far" (which performs well when replay buffer is small but do NOT scale to cases where there are a lot of actors and replay buffer is large) or the "current n-step TD error" (as you suggested, which requires an additional prediction step), we can make this configurable.

<img width="800" alt="init" src="https://user-images.githubusercontent.com/29387830/77222236-7a67c280-6b1f-11ea-92d8-1554dd9179c5.png">

Let me know if my points make sense to you!
