### PR TITLE
IS weights for prioritized replay

### DIFF
--- a/games/lunarlander.py
+++ b/games/lunarlander.py
@@ -76,6 +76,7 @@ class MuZeroConfig:
         # Prioritized Replay
         self.PER = True
         self.PER_alpha = 0.5
+        self.PER_beta = 1.0
 
         # Exponential learning rate schedule
         self.lr_init = 0.005  # Initial learning rate


### PR DESCRIPTION
Hey,

I implemented the IS weights based on my understanding. In `replay_buffer.py`, I calculated $N$ and $P(i)$ according to the total number of samples in buffer and game/position sampling probabilities (with parameter `self.PER_beta`). Then I normalize weights by 1/ maxi wi after getting the `weight_batch`. During training, the `weights_batch` is multiplied by the loss of each data sample.