### PR TITLE
Fix reward for more than 2 players or non alternating games

### DIFF
--- a/self_play.py
+++ b/self_play.py
@@ -78,8 +78,8 @@ class SelfPlay:
                             [
                                 reward
                                 for i, reward in enumerate(game_history.reward_history)
-                                if game_history.to_play_history[i]
-                                == (1 - self.config.muzero_player)
+                                if game_history.to_play_history[i-1]
+                                == self.config.muzero_player
                             ]
                         ),
                     )
@@ -89,8 +89,8 @@ class SelfPlay:
                             [
                                 reward
                                 for i, reward in enumerate(game_history.reward_history)
-                                if game_history.to_play_history[i]
-                                == self.config.muzero_player
+                                if game_history.to_play_history[i-1]
+                                != self.config.muzero_player
                             ]
                         ),
                     )


### PR DESCRIPTION
When you have more than two players or the game wouldn't be played alternately between the players, the reward wouldn't be shown in tensorboard correctly.