### PR TITLE
Add reanalyse_on_gpu for gomoku

### DIFF
--- a/games/gomoku.py
+++ b/games/gomoku.py
@@ -103,6 +103,7 @@ class MuZeroConfig:
         self.use_last_model_value = False  # Use the last model to provide a fresher, stable n-step value (See paper appendix Reanalyze)
         self.reanalyse_device = "cpu"  # "cpu" / "cuda"
         self.reanalyse_num_gpus = 0  # Number of GPUs to use for the reanalyse, it can be fractional, don't fortget to take the train worker and the selfplay workers into account
+        self.reanalyse_on_gpu = self.reanalyse_device == "gpu"
 
 
 

--- a/games/gomoku.py
+++ b/games/gomoku.py
@@ -103,7 +103,7 @@ class MuZeroConfig:
         self.use_last_model_value = False  # Use the last model to provide a fresher, stable n-step value (See paper appendix Reanalyze)
         self.reanalyse_device = "cpu"  # "cpu" / "cuda"
         self.reanalyse_num_gpus = 0  # Number of GPUs to use for the reanalyse, it can be fractional, don't fortget to take the train worker and the selfplay workers into account
-        self.reanalyse_on_gpu = self.reanalyse_device == "gpu"
+        self.reanalyse_on_gpu = self.reanalyse_device == "cuda"
 
 
 


### PR DESCRIPTION
Running gomoku training via `python muzero.py` fails due to the following error:
```
Enter a number to choose an action: 0
Traceback (most recent call last):
  File "muzero.py", line 613, in <module>
    muzero.train()
  File "muzero.py", line 142, in train
    + self.config.use_last_model_value * self.config.reanalyse_on_gpu
AttributeError: 'MuZeroConfig' object has no attribute 'reanalyse_on_gpu'
```

I noticed the other games just set this to False directly, while gomoku has separate entries for self.reanalyse_device and self.reanalyse_num_gpus. 