### PR TITLE
Added submenu for simpler loading of pre-trained models

### DIFF
--- a/muzero.py
+++ b/muzero.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import sys
 import time
+from glob import glob
 
 import nevergrad
 import numpy
@@ -560,6 +561,42 @@ def hyperparameter_search(
         text_file.close()
     return recommendation.value
 
+def load_model_menu(muzero, game_name):
+    # Configure running options
+    options = ["Specify paths manually"] + sorted(glob(f"results/{game_name}/*/"))
+    options.reverse()
+    print()
+    for i in range(len(options)):
+        print(f"{i}. {options[i]}")
+
+    choice = input("Enter a number to choose a model to load: ")
+    valid_inputs = [str(i) for i in range(len(options))]
+    while choice not in valid_inputs:
+        choice = input("Invalid input, enter a number listed above: ")
+    choice = int(choice)
+
+    if choice == (len(options) - 1):
+        # manual path option
+        checkpoint_path = input(
+            "Enter a path to the model.checkpoint, or ENTER if none: "
+        )
+        while checkpoint_path and not os.path.isfile(checkpoint_path):
+            checkpoint_path = input("Invalid checkpoint path. Try again: ")
+        replay_buffer_path = input(
+            "Enter a path to the replay_buffer.pkl, or ENTER if none: "
+        )
+        while replay_buffer_path and not os.path.isfile(replay_buffer_path):
+            replay_buffer_path = input(
+                "Invalid replay buffer path. Try again: "
+            )
+    else:
+        checkpoint_path = f"{options[choice]}model.checkpoint"
+        replay_buffer_path = f"{options[choice]}replay_buffer.pkl"
+
+    muzero.load_model(
+        checkpoint_path=checkpoint_path,
+        replay_buffer_path=replay_buffer_path,
+    )
 
 if __name__ == "__main__":
     if len(sys.argv) == 2:
@@ -612,22 +649,7 @@ if __name__ == "__main__":
             if choice == 0:
                 muzero.train()
             elif choice == 1:
-                checkpoint_path = input(
-                    "Enter a path to the model.checkpoint, or ENTER if none: "
-                )
-                while checkpoint_path and not os.path.isfile(checkpoint_path):
-                    checkpoint_path = input("Invalid checkpoint path. Try again: ")
-                replay_buffer_path = input(
-                    "Enter a path to the replay_buffer.pkl, or ENTER if none: "
-                )
-                while replay_buffer_path and not os.path.isfile(replay_buffer_path):
-                    replay_buffer_path = input(
-                        "Invalid replay buffer path. Try again: "
-                    )
-                muzero.load_model(
-                    checkpoint_path=checkpoint_path,
-                    replay_buffer_path=replay_buffer_path,
-                )
+                load_model_menu(muzero, game_name)
             elif choice == 2:
                 muzero.diagnose_model(30)
             elif choice == 3:


### PR DESCRIPTION
Added a small sub-routine that scans for previously
saved models. These can be loaded by simply selecting
the menu option instead of providing the full path.
The menu is presented in reverse chronological order
and the final option "Specify paths manually" preserves
the ability to provide a full path for the checkpoint
and replay buffer as was done previously.

This is probably best understood by looking at an example. Showing user input **in bold**, previously the UI flow for loading a model was:

<pre>
0. Train
1. Load pretrained model
2. Diagnose model
3. Render some self play games
4. Play against MuZero
5. Test the game manually
6. Hyperparameter search
7. Exit
Enter a number to choose an action: <b>1</b>
Enter a path to the model.checkpoint, or ENTER if none: <b>results/cartpole/2020-12-28--21-53-13/model.checkpoint</b>
Enter a path to the replay_buffer.pkl, or ENTER if none: <b>results/cartpole/2020-12-28--21-53-13/replay_buffer.pkl</b>

Using checkpoint from results/cartpole/2020-12-28--21-53-13/model.checkpoint
Initializing replay buffer with results/cartpole/2020-12-28--21-53-13/replay_buffer.pkl
Done
</pre>

And after changes it becomes:

<pre>
0. Train
1. Load pretrained model
2. Diagnose model
3. Render some self play games
4. Play against MuZero
5. Test the game manually
6. Hyperparameter search
7. Exit
Enter a number to choose an action: <b>1</b>

0. results/cartpole/2021-01-03--01-53-29/
1. results/cartpole/2020-12-28--21-59-16/
2. results/cartpole/2020-12-28--21-58-40/
3. results/cartpole/2020-12-28--21-53-13/
4. Specify paths manually
Enter a number to choose a model to load: <b>0</b>

Using checkpoint from results/cartpole/2021-01-03--01-53-29/model.checkpoint
Initializing replay buffer with results/cartpole/2021-01-03--01-53-29/replay_buffer.pkl
Done
</pre>

Just an idea, no worries if you don't want to merge this into master as I can also appreciate a dead simple demo program.