### PR TITLE
fix reward sign in compute_target_value()

### DIFF
--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -229,7 +229,7 @@ class ReplayBuffer:
             value += (
                 reward
                 if game_history.to_play_history[index]
-                == game_history.to_play_history[index + 1 + i]
+                == game_history.to_play_history[index + 1 + i - 1]  # player[i-i] got reward[i]
                 else -reward
             ) * self.config.discount ** i
 


### PR DESCRIPTION
Hi,

Thank you for your great implementation!

I found a ploblem in `ReplayBuffer.compute_target_value()` about two players games.
Because player[i-1] got reward[i] in GameHistory, the reward sign is reversed in current implementation.

I tested performance with tictactoe(modified hyper parameters[A]), the patched version worked well.
Around about 200k training steps, the expert almost did not win.
Around about 200k training steps, MuZero won about 45% (50% is expected rate to the expert). 

[A] tictactoe hyper parameters
------------

- support_size = 1  
- num_unroll_steps = 3
- td_steps = 9

![image](https://user-images.githubusercontent.com/606549/103974633-96734800-51b5-11eb-8167-9004d52aff24.png)
![image](https://user-images.githubusercontent.com/606549/103974775-dcc8a700-51b5-11eb-94fc-8834051a946d.png)
![image](https://user-images.githubusercontent.com/606549/103974878-0da8dc00-51b6-11eb-934d-db2090d47403.png)
