### PR TITLE
fix MCTS backpropagate() about two-player game

### DIFF
--- a/self_play.py
+++ b/self_play.py
@@ -419,13 +419,11 @@ class MCTS:
 
         elif len(self.config.players) == 2:
             for node in reversed(search_path):
-                node.value_sum += value if node.to_play == to_play else -value
+                node.value_sum += value
                 node.visit_count += 1
                 min_max_stats.update(node.reward + self.config.discount * -node.value())
 
-                value = (
-                    -node.reward if node.to_play == to_play else node.reward
-                ) + self.config.discount * value
+                value = node.reward - self.config.discount * value
 
         else:
             raise NotImplementedError("More than two player mode not implemented.")


### PR DESCRIPTION
Hi, I'm sending a PR because I think the implementation is a bit strange.
Could you please consider this?

-------------

| Node | to_play | action | real reward | ideal predicted value | ideal predicted reward | note | 
|-----|-----|-----|-----|-----|-----|-----| 
| node0(root) | PlayerA | x | 0 | ? | 0 |  | 
| node1 | PlayerB | y | 0 | 1 | 0 |  | 
| node2 | PlayerA |  z | 1 | 0 | 1 | PlayerB win! | 

Let's consider this situation in MCTS.
You are currently at node0, and it is PlayerA's turn.
Suppose node1 is expanded and PlayerB has the next move(z) to win.
In this case, the ideal predicted value at the time of node1 expansion is 1 (when not discounted).

Consider backpropagate() immediately after this node1 expansion.
The search_path contains [node0, node1].

In the current implementation,

```
node.value_sum += value if node.to_play == to_play else -value
```

`to_play` is `node0.to_play`, So, node1's value_sum will be -1.
I think this is wrong, because when calculating the UCB score, we always use -child.value() (in two player game).
We don't want node1(=move y) to be selected for node0, so node1.value_sum should have 1 added to it.

When node2 is expanded, the reward of node2 is reflected in the value of node1 and node0, which I think is reflected with the correct sign.
So a few searches will reduce the impact, but otherwise it will be easy to choose the wrong move.

---------------

These are test results about connect4.
Gray(A) line is the result after applying [PR-108](https://github.com/werner-duvaud/muzero-general/pull/108).
Orange(B) line is the result after applying [PR-108](https://github.com/werner-duvaud/muzero-general/pull/108) and this PR.

Both have a fair amount of learning going on, and I think it's hard to judge which is better on its own, but I think it shows that B's implementation doesn't cause any particular problems.

![image](https://user-images.githubusercontent.com/606549/105431758-a3099d00-5c99-11eb-955b-19526b88b5d1.png)

![image](https://user-images.githubusercontent.com/606549/105432155-6a1df800-5c9a-11eb-8c73-2c5a838d32e4.png)

![image](https://user-images.githubusercontent.com/606549/105431814-c03e6b80-5c99-11eb-99e3-6452d6cb8286.png)


