### PR TITLE
repeat last reward after teminate state in make_target()

### DIFF
--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -240,6 +240,7 @@ class ReplayBuffer:
         Generate targets for every unroll steps.
         """
         target_values, target_rewards, target_policies, actions = [], [], [], []
+        last_reward = 0
         for current_index in range(
             state_index, state_index + self.config.num_unroll_steps + 1
         ):
@@ -252,7 +253,8 @@ class ReplayBuffer:
                 actions.append(game_history.action_history[current_index])
             elif current_index == len(game_history.root_values):
                 target_values.append(0)
-                target_rewards.append(game_history.reward_history[current_index])
+                last_reward = game_history.reward_history[current_index]
+                target_rewards.append(last_reward)
                 # Uniform policy
                 target_policies.append(
                     [
@@ -264,7 +266,9 @@ class ReplayBuffer:
             else:
                 # States past the end of games are treated as absorbing states
                 target_values.append(0)
-                target_rewards.append(0)
+                if len(self.config.players) > 1:
+                    last_reward = -last_reward
+                target_rewards.append(last_reward)
                 # Uniform policy
                 target_policies.append(
                     [


### PR DESCRIPTION
This is a suggestion to make learning better.

In the papar,
> 3) Terminal nodes. AlphaZero stopped the search at tree nodes representing terminal states and used the terminal value provided by the simulator instead of the value produced by the network. MuZero does not give
> special treatment to terminal nodes and always uses the value predicted by the network. Inside the tree, the
> search can proceed past a terminal node - in this case the network is expected to always predict the same
> value. This is achieved by treating terminal states as absorbing states during training

What is "the same value"?
In the current implemantation, after terminating game, values and rewards are always 0.
In this new implementation, values are 0, but rewards are last_reward value.

This way, when the node is expanded past the end state in MCTS, the reword is repeated, which makes the choice clearer and leads to good policy learning.

---------------

These are test results about connect4.
Orange(A) line is the result after applying [PR-108](https://github.com/werner-duvaud/muzero-general/pull/108) and [PR-121](https://github.com/werner-duvaud/muzero-general/pull/121).
Blue(B) line is the result after applying [PR-108](https://github.com/werner-duvaud/muzero-general/pull/108), [PR-121](https://github.com/werner-duvaud/muzero-general/pull/121), and this PR.

Both are in the process of learning, but MuZero_reward shows that B is more advanced in its learning.

![image](https://user-images.githubusercontent.com/606549/105432963-085e8d80-5c9c-11eb-8880-a4f338543272.png)

![image](https://user-images.githubusercontent.com/606549/105433001-1ad8c700-5c9c-11eb-9593-766c3f3d0674.png)

![image](https://user-images.githubusercontent.com/606549/105433033-2c21d380-5c9c-11eb-844b-82cd1955c1dc.png)
