### PR TITLE
Keep replay buffer on disk (not in memory), allowing it to grow to any size.

### DIFF
--- a/muzero.py
+++ b/muzero.py
@@ -110,7 +110,7 @@ class MuZero:
             "num_reanalysed_games": 0,
             "terminate": False,
         }
-        self.replay_buffer = {}
+        self.replay_buffer = os.path.join(self.config.results_path, "replay_buffer.db")
 
         cpu_actor = CPUActor.remote()
         cpu_weights = cpu_actor.get_initial_weights.remote(self.config)

--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -281,20 +281,27 @@ class ReplayBuffer:
 
             # The element could have been removed since its selection and training
             if next(iter(self.buffer)) <= game_id:
+
+                # select record from database (can't update in place)
+                game_history = self.buffer[game_id]
+
                 # Update position priorities
                 priority = priorities[i, :]
                 start_index = game_pos
                 end_index = min(
-                    game_pos + len(priority), len(self.buffer[game_id].priorities)
+                    game_pos + len(priority), len(game_history.priorities)
                 )
-                self.buffer[game_id].priorities[start_index:end_index] = priority[
+                game_history.priorities[start_index:end_index] = priority[
                     : end_index - start_index
                 ]
 
                 # Update game priorities
-                self.buffer[game_id].game_priority = numpy.max(
+                game_history.game_priority = numpy.max(
                     self.buffer[game_id].priorities
                 )
+
+                # update record
+                self.buffer[game_id] = game_history
 
     def compute_target_value(self, game_history, index):
         # The value target is the discounted root value of the search tree td_steps into the


### PR DESCRIPTION
Hello, please consider this pull request which I implemented based on [this comment](https://github.com/werner-duvaud/muzero-general/issues/102#issuecomment-753306860).

Mainly I added a GameHistoryDao class which creates "replay_buffer.db" with a simple key->value table and stores the games there like a dictionary. If this approach is good, then it can be optimized further by separating reanalysed_predicted_root_values, priorities, and game_priority into their own columns so it can avoid serializing/deserializing the full observation history at each update. However, I think that would take more invasive changes to the existing code.