### PR TITLE
Bugfix: Nevergrad changed the name of the Log function arguments.

### DIFF
--- a/muzero.py
+++ b/muzero.py
@@ -667,7 +667,7 @@ if __name__ == "__main__":
                 del muzero
                 budget = 20
                 parallel_experiments = 2
-                lr_init = nevergrad.p.Log(a_min=0.0001, a_max=0.1)
+                lr_init = nevergrad.p.Log(lower=0.0001, upper=0.1)
                 discount = nevergrad.p.Log(lower=0.95, upper=0.9999)
                 parametrization = nevergrad.p.Dict(lr_init=lr_init, discount=discount)
                 best_hyperparameters = hyperparameter_search(


### PR DESCRIPTION
As you can see in this pull request: 

https://github.com/facebookresearch/nevergrad/commit/4ed9a7096e1a6cfeada5ea40a10ef61ef0b7db16

The parameters for Log have been changed. The pull request says it would return a deprecation warning but I received an error when running choice 6. After changing the parameter names, the code worked again.