### PR TITLE
fix a bug due to the use of DataParallel

### DIFF
--- a/diagnose_model.py
+++ b/diagnose_model.py
@@ -23,6 +23,7 @@ class DiagnoseModel:
         # Initialize the network
         self.model = models.MuZeroNetwork(self.config)
         self.model.set_weights(checkpoint["weights"])
+        self.model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu")) # on GPU if available since the DataParallel objects in MuZeroNetwork requires that  
         self.model.eval()
 
     def get_virtual_trajectory_from_obs(

--- a/diagnose_model.py
+++ b/diagnose_model.py
@@ -23,7 +23,9 @@ class DiagnoseModel:
         # Initialize the network
         self.model = models.MuZeroNetwork(self.config)
         self.model.set_weights(checkpoint["weights"])
-        self.model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu")) # on GPU if available since the DataParallel objects in MuZeroNetwork requires that  
+        self.model.to(
+            torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        )  # on GPU if available since the DataParallel objects in MuZeroNetwork requires that
         self.model.eval()
 
     def get_virtual_trajectory_from_obs(


### PR DESCRIPTION
This PR is to fix the issue in DiagnoseModel around the proper use of DataParallel.

### To reproduce:

Run `python muzero.py` on a machine with CUDA available, choose an environment from the command line prompt, then choose "Diagnose model". 
The following error message should come up regardless of whether the config file specified to use GPU or not as long as the GPU is visible to torch.

### Error message:

`module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu`

### Similar Issues
#174 
where the error message was the same as here but triggered from a different scenario.

### Cause of Issue:

The [models](https://github.com/werner-duvaud/muzero-general/blob/master/models.py#L98) of MuZero use [DataParallel](https://pytorch.org/docs/1.8.1/generated/torch.nn.DataParallel.html?highlight=dataparallel#torch.nn.DataParallel) which requires that the model is loaded to GPU if available.
