### PR TITLE
Fix requirements in ci

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements.lock
 
       - name: Training test
         shell: bash

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Network summary:
 git clone https://github.com/werner-duvaud/muzero-general.git
 cd muzero-general
 
-pip install -r requirements.txt
+pip install -r requirements.lock
 ```
 
 ### Run


### PR DESCRIPTION
Protobuf update broke ray.
Also https://github.com/protocolbuffers/protobuf/issues/10051

Let's default to installing requirements.lock and we will try to upgrade deps from time to time.