### PR TITLE
Switch architecture to parallel sync ray tasks

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -15,8 +15,16 @@ class Trainer:
     in the shared storage.
     """
 
-    def __init__(self, initial_checkpoint, config):
+    def __init__(self,
+        shared_storage,
+        replay_buffer,
+        initial_checkpoint,
+        config,
+        ):
         self.config = config
+
+        self._shared_storage = shared_storage
+        self._replay_buffer = replay_buffer
 
         # Fix random generator seed
         numpy.random.seed(self.config.seed)
@@ -58,18 +66,18 @@ class Trainer:
                 copy.deepcopy(initial_checkpoint["optimizer_state"])
             )
 
-    def continuous_update_weights(self, replay_buffer, shared_storage):
+    def continuous_update_weights(self):
         # Wait for the replay buffer to be filled
-        while ray.get(shared_storage.get_info.remote("num_played_games")) < 1:
+        while ray.get(self._shared_storage.get_info.remote("num_played_games")) < 1:
             time.sleep(0.1)
 
-        next_batch = replay_buffer.get_batch.remote()
+        next_batch = self._replay_buffer.get_batch.remote()
         # Training loop
         while self.training_step < self.config.training_steps and not ray.get(
-            shared_storage.get_info.remote("terminate")
+            self._shared_storage.get_info.remote("terminate")
         ):
             index_batch, batch = ray.get(next_batch)
-            next_batch = replay_buffer.get_batch.remote()
+            next_batch = self._replay_buffer.get_batch.remote()
             self.update_lr()
             (
                 priorities,
@@ -81,11 +89,11 @@ class Trainer:
 
             if self.config.PER:
                 # Save new priorities in the replay buffer (See https://arxiv.org/abs/1803.00933)
-                replay_buffer.update_priorities.remote(priorities, index_batch)
+                self._replay_buffer.update_priorities.remote(priorities, index_batch)
 
             # Save to the shared storage
             if self.training_step % self.config.checkpoint_interval == 0:
-                shared_storage.set_info.remote(
+                self._shared_storage.set_info.remote(
                     {
                         "weights": copy.deepcopy(self.model.get_weights()),
                         "optimizer_state": copy.deepcopy(
@@ -94,8 +102,8 @@ class Trainer:
                     }
                 )
                 if self.config.save_model:
-                    shared_storage.save_checkpoint.remote()
-            shared_storage.set_info.remote(
+                    self._shared_storage.save_checkpoint.remote()
+            self._shared_storage.set_info.remote(
                 {
                     "training_step": self.training_step,
                     "lr": self.optimizer.param_groups[0]["lr"],
@@ -113,11 +121,11 @@ class Trainer:
                 while (
                     self.training_step
                     / max(
-                        1, ray.get(shared_storage.get_info.remote("num_played_steps"))
+                        1, ray.get(self._shared_storage.get_info.remote("num_played_steps"))
                     )
                     > self.config.ratio
                     and self.training_step < self.config.training_steps
-                    and not ray.get(shared_storage.get_info.remote("terminate"))
+                    and not ray.get(self._shared_storage.get_info.remote("terminate"))
                 ):
                     time.sleep(0.5)
 


### PR DESCRIPTION
This request proposition is to open debate about sync tasks, instead of async

Pro:
- allow easier task debugging: just enable ray.init(local_mode=True), then every tasks will be processed in the same process
- better reproducibility
- remove time.sleep who consume resources for no compute
- Good resource usage using double buffering: we push one task ahead for workers, so they keep computing while driver's process is doing sync. I could provide a ray timeline.json, or it could be generated from code (just look at timeline.json)
- simplify code : remove "terminate" flag management

Cons:
- Maybe scale a bit less one huge clusters

Note:
- tested on cartpole
- move tensorboard logging to a new worker
